### PR TITLE
Scene scope fixes for 6.6 - 7.2

### DIFF
--- a/D2GI/src/d2gi/d2gi.cpp
+++ b/D2GI/src/d2gi/d2gi.cpp
@@ -491,7 +491,7 @@ VOID D2GI::OnSceneEnd()
 
 VOID D2GI::TryEndScene()
 {
-	if (--m_SceneBeginCount == 0)
+	if (m_SceneBeginCount > 0 && --m_SceneBeginCount == 0)
 	{
 		m_pDev->EndScene();
 	}
@@ -800,10 +800,23 @@ VOID D2GI::OnClipStatusSet(D3D7::LPD3DCLIPSTATUS pStatus)
 
 VOID D2GI::Present()
 {
+	// In D3D7 it was allowed to call Present inside a BeginScene/EndScene pair, but in D3D9 it's not.
+	bool bRestartScene = false;
+	if (m_SceneBeginCount > 0)
+	{
+		m_pDev->EndScene();
+		bRestartScene = true;
+	}
+
 	const HRESULT hr = m_pDev->Present(NULL, NULL, NULL, NULL);
 
 	if (hr == D3DERR_DEVICELOST)
 		ResetD3D9Device();
+
+	if (bRestartScene)
+	{
+		m_pDev->BeginScene();
+	}
 }
 
 

--- a/D2GI/src/d2gi/d2gi.h
+++ b/D2GI/src/d2gi/d2gi.h
@@ -57,7 +57,7 @@ class D2GI
 	FLOAT m_fAspectRatioScale, m_fWidthScale, m_fHeightScale;
 
 	RENDERSTATE m_eRenderState;
-	DWORD m_SceneBeginCount = 0;
+	int32_t m_SceneBeginCount = 0;
 	BOOL m_bColorKeyEnabled;
 	D2GITexture* m_lpCurrentTextures[8];
 


### PR DESCRIPTION
Fixes the scene refcounting when the game over-Ends scenes, and ends the scene before Present

* 6.9 was over-releasing the scene, which is allowed in D3D7/D3D9, but in D2GI it broke the reference counting.
* These versions of the game Present from inside the scene scope, but it's not allowed in D3D9.

Fixes #39.

<img width="1026" height="797" alt="image" src="https://github.com/user-attachments/assets/7a5bf33a-fbec-4ebf-a91c-5671e7106715" />