### PR TITLE
Remove cabines.pribor from the UV overrides

### DIFF
--- a/D2GI/d2gi.ini
+++ b/D2GI/d2gi.ini
@@ -31,4 +31,3 @@ ImageFormat = jpg
 ; Allowed modes: CLAMP, WRAP, MIRROR
 ; Mostly used to fix 1px-wide seams on trees and other transparent textures when MSAA is enabled.
 aq.forest1, CLAMP, WRAP
-cabines.pribor, CLAMP, CLAMP


### PR DESCRIPTION
This texture is used for more than just wipers, and expects wrapping in some cases.

Fixes #42.